### PR TITLE
Deprecate bucket.peek, redundant; rethink locking

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -6,23 +6,49 @@ import (
 	"time"
 )
 
-type bucket struct {
+// Bucket is the primitive that tracks tokens.
+type Bucket struct {
 	time time.Time
 	mu   sync.RWMutex
 }
 
-func newBucket(executionTime time.Time, limit Limit) *bucket {
-	return &bucket{
+// NewBucket creates a new bucket with the current time and a given limit.
+// Further checks of the bucket's status must pass the same limit.
+func NewBucket(limit Limit) *Bucket {
+	return newBucket(time.Now(), limit)
+}
+
+func newBucket(executionTime time.Time, limit Limit) *Bucket {
+	return &Bucket{
+		// subtracting the period represents filling it with tokens
 		time: executionTime.Add(-limit.period),
 	}
 }
 
-// allow returns true if there are available tokens in the bucket, and consumes a token if so.
-// If it returns false, no tokens were consumed.
-func (b *bucket) allow(executionTime time.Time, limit Limit) bool {
+// Allow returns true if tokens are available in the bucket for the given execution time and limit.
+// If a token is available, it returns true and consumes a token.
+// If no token is available, it returns false and does not consume a token.
+// It is thread-safe.
+func (b *Bucket) Allow(executionTime time.Time, limit Limit) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.allow(executionTime, limit)
+}
 
+/*
+The private methods (mostly) are meant to be called from within
+the public methods that handle locking. Public methods are
+intended to be thread-safe, and safely callable.
+
+Private methods offer primitives allowing higher-level logic,
+such as in Limiter, for fine control.
+*/
+
+// allow returns true if there are available tokens in the bucket, and consumes a token if so.
+// If it returns false, no tokens were consumed.
+//
+// ⚠️ caller is responsible for locking appropriately
+func (b *Bucket) allow(executionTime time.Time, limit Limit) bool {
 	if b.hasToken(executionTime, limit) {
 		// If the bucket is old, it should not mistakenly be interpreted as having too many tokens
 		cutoff := executionTime.Add(-limit.period)
@@ -35,36 +61,65 @@ func (b *bucket) allow(executionTime time.Time, limit Limit) bool {
 	return false
 }
 
-// peek returns true if there are available tokens in the bucket,
-// but consumes no tokens and mutates no state.
-func (b *bucket) peek(executionTime time.Time, limit Limit) bool {
+// HasToken checks if there are available tokens in the bucket
+func (b *Bucket) HasToken(executionTime time.Time, limit Limit) bool {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return b.hasToken(executionTime, limit)
 }
 
 // hasToken checks if any tokens are available in the bucket
-// ⚠️ assumes the caller has locked appropriately
-func (b *bucket) hasToken(executionTime time.Time, limit Limit) bool {
+//
+// ⚠️ caller is responsible for locking appropriately
+func (b *Bucket) hasToken(executionTime time.Time, limit Limit) bool {
 	return !b.time.After(executionTime.Add(-limit.durationPerToken))
 }
 
+// ConsumeToken removes one token from the bucket
+func (b *Bucket) ConsumeToken(limit Limit) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.hasToken(time.Now(), limit) {
+		b.consumeToken(limit)
+	}
+}
+
 // consumeToken removes one token from the bucket
-// ⚠️ assumes the caller has locked appropriately
-func (b *bucket) consumeToken(limit Limit) {
+//
+// ⚠️ caller is responsible for locking appropriately
+func (b *Bucket) consumeToken(limit Limit) {
 	b.time = b.time.Add(limit.durationPerToken)
 }
 
-// remainingTokens returns the number of tokens remaining in the bucket
-func (b *bucket) remainingTokens(executionTime time.Time, limit Limit) int64 {
+// RemainingTokens returns the number of tokens remaining in the bucket
+func (b *Bucket) RemainingTokens(executionTime time.Time, limit Limit) int64 {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return remainingTokens(executionTime, b.time, limit)
 }
 
-func (b *bucket) nextTokenTime(limit Limit) time.Time {
+// remainingTokens returns the number of tokens remaining in the bucket
+//
+// ⚠️ caller is responsible for locking appropriately
+func (b *Bucket) remainingTokens(executionTime time.Time, limit Limit) int64 {
+	return remainingTokens(executionTime, b.time, limit)
+}
+
+// NextTokenTime returns the time when the next token might be available
+// Note that concurrent access by other goroutines might consume tokens;
+// treat NextTokenTime as a prediction, not a guarantee.
+func (b *Bucket) NextTokenTime(limit Limit) time.Time {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+	return b.nextTokenTime(limit)
+}
+
+// nextTokenTime returns the time when the next token might be available
+// Note that concurrent access by other goroutines might consume tokens;
+// treat nextTokenTime as a prediction, not a guarantee.
+//
+// ⚠️ caller is responsible for locking appropriately
+func (b *Bucket) nextTokenTime(limit Limit) time.Time {
 	return b.time.Add(limit.durationPerToken)
 }
 
@@ -82,7 +137,7 @@ func remainingTokens(executionTime time.Time, bucketTime time.Time, limit Limit)
 // or the allow succeeds.
 //
 // As with [allow], it returns true if a token was acquired, false if not.
-func (b *bucket) wait(ctx context.Context, startTime time.Time, limit Limit) bool {
+func (b *Bucket) wait(ctx context.Context, startTime time.Time, limit Limit) bool {
 	return b.waitWithCancellation(
 		startTime,
 		limit,
@@ -93,7 +148,7 @@ func (b *bucket) wait(ctx context.Context, startTime time.Time, limit Limit) boo
 
 // waitWithCancellation is a more testable version of wait that accepts
 // deadline and done functions instead of a context, allowing for deterministic testing.
-func (b *bucket) waitWithCancellation(
+func (b *Bucket) waitWithCancellation(
 	startTime time.Time,
 	limit Limit,
 	deadline func() (time.Time, bool),
@@ -104,11 +159,14 @@ func (b *bucket) waitWithCancellation(
 	currentTime := startTime
 
 	for {
+		b.mu.Lock()
 		if b.allow(currentTime, limit) {
+			b.mu.Unlock()
 			return true
 		}
 
 		nextToken := b.nextTokenTime(limit)
+		b.mu.Unlock()
 
 		// early return if we can't possibly acquire a token before the context is done
 		if deadline, ok := deadline(); ok {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -29,6 +29,42 @@ func TestBucket_RemainingTokens(t *testing.T) {
 	}
 }
 
+func TestBucket_RemainingTokens_Concurrent(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	limit := NewLimit(100, time.Second)
+	bucket := newBucket(now, limit)
+
+	// Number of concurrent operations
+	const numOps = 200
+
+	var wg sync.WaitGroup
+	for i := range numOps {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Interleave consumption and reading
+			if i%2 == 0 {
+				bucket.ConsumeToken(limit)
+				return
+			}
+
+			// We can't assert a specific value, but we can ensure it's within bounds
+			// and doesn't crash.
+			remaining := bucket.RemainingTokens(now, limit)
+			require.GreaterOrEqual(t, remaining, int64(0), "remaining tokens should not be negative")
+			require.LessOrEqual(t, remaining, limit.count, "remaining tokens should not exceed limit")
+
+		}(i)
+	}
+	wg.Wait()
+
+	// 100 tokens should have been consumed after all
+	expected := limit.count - (numOps / 2)
+	actual := bucket.RemainingTokens(now, limit)
+	require.Equal(t, expected, actual, "final token count should be correct")
+}
+
 func TestBucket_ConsumeToken(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
@@ -102,24 +138,24 @@ func TestBucket_Allow_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(processID int64) {
 			defer wg.Done()
-			actual := bucket.allow(now, limit)
+			actual := bucket.Allow(now, limit)
 			require.True(t, actual, "expected to allow request when tokens are available (goroutine %d)", processID)
 		}(processID)
 	}
 	wg.Wait()
 
 	// Tokens should be gone now
-	actual := bucket.allow(now, limit)
+	actual := bucket.Allow(now, limit)
 	require.False(t, actual, "expected to deny request after tokens are exhausted")
 
 	now = now.Add(limit.durationPerToken)
 
 	// A new token should have refilled by now
-	actual = bucket.allow(now, limit)
+	actual = bucket.Allow(now, limit)
 	require.True(t, actual, "expected to allow request after waiting for refill")
 }
 
-func TestBucket_Peek(t *testing.T) {
+func TestBucket_HasToken(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 
@@ -129,7 +165,7 @@ func TestBucket_Peek(t *testing.T) {
 
 	for range limit.count * 2 {
 		// any number of peeks should return true
-		actual := bucket.peek(now, limit)
+		actual := bucket.hasToken(now, limit)
 		require.True(t, actual, "expected to allow request with any number of peeks")
 	}
 
@@ -143,16 +179,16 @@ func TestBucket_Peek(t *testing.T) {
 
 	for range limit.count * 2 {
 		// any number of peeks should return false with no remianing tokens
-		actual := bucket.peek(now, limit)
+		actual := bucket.hasToken(now, limit)
 		require.False(t, actual, "expected to deny peek requests when all tokens are gone")
 	}
 
 	// Refill one token
 	now = now.Add(limit.durationPerToken)
-	require.True(t, bucket.peek(now, limit), "peek should return true after tokens refill")
+	require.True(t, bucket.hasToken(now, limit), "peek should return true after tokens refill")
 }
 
-func TestBucket_Peek_Concurrent(t *testing.T) {
+func TestBucket_HasToken_Concurrent(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 
@@ -167,7 +203,7 @@ func TestBucket_Peek_Concurrent(t *testing.T) {
 			wg.Add(1)
 			go func(processID int64) {
 				defer wg.Done()
-				actual := bucket.peek(now, limit)
+				actual := bucket.HasToken(now, limit)
 				require.True(t, actual, "expected any number of peeks to be true (goroutine %d)", processID)
 			}(processID)
 		}
@@ -181,9 +217,9 @@ func TestBucket_Peek_Concurrent(t *testing.T) {
 			wg.Add(1)
 			go func(processID int64) {
 				defer wg.Done()
-				peek := bucket.peek(now, limit)
+				peek := bucket.HasToken(now, limit)
 				require.True(t, peek, "expected peek to be true (goroutine %d)", processID)
-				allow := bucket.allow(now, limit)
+				allow := bucket.Allow(now, limit)
 				require.True(t, allow, "expected allow to be true (goroutine %d)", processID)
 			}(processID)
 		}
@@ -206,10 +242,10 @@ func TestBucket_Wait_Concurrent(t *testing.T) {
 	// All tokens should be exhausted
 	require.False(t, bucket.allow(now, limit), "should not allow when tokens exhausted")
 
-	var wg sync.WaitGroup
 	ctx := context.Background()
 
 	// These waits should queue up and execute as tokens become available
+	var wg sync.WaitGroup
 	for processID := range limit.count {
 		wg.Add(1)
 		go func(processID int64) {
@@ -218,7 +254,6 @@ func TestBucket_Wait_Concurrent(t *testing.T) {
 			require.True(t, allow, "should acquire token after waiting (goroutine %d)", processID)
 		}(processID)
 	}
-
 	wg.Wait()
 
 	// All tokens should be exhausted again

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clipperhouse/rate
 
-go 1.24.4
+go 1.24
 
 require github.com/stretchr/testify v1.10.0
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -59,9 +59,8 @@ func TestLimiter_Allow_MultipleBuckets_Concurrent(t *testing.T) {
 	limiter := NewLimiter(keyer, limit)
 	start := time.Now()
 
-	var wg sync.WaitGroup
-
 	// Enough concurrent processes for each bucket to precisely exhaust the limit
+	var wg sync.WaitGroup
 	for bucketID := range buckets {
 		for processID := range limit.count {
 			wg.Add(1)
@@ -72,7 +71,6 @@ func TestLimiter_Allow_MultipleBuckets_Concurrent(t *testing.T) {
 			}(bucketID, processID)
 		}
 	}
-
 	wg.Wait()
 
 	// Verify that additional requests are rejected, all buckets should be exhausted


### PR DESCRIPTION
Move the locking out of the private primitives, let it be a concern of callers.

Establish a convention that public methods are thread-safe.
