### PR TITLE
Allow multiple limits [WIP, do not merge]

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -7,10 +7,10 @@ import (
 
 // Limiter is a rate limiter that can be used to limit the rate of requests to a given key.
 type Limiter[TInput any, TKey comparable] struct {
-	keyer     Keyer[TInput, TKey]
-	limit     Limit
-	limitFunc LimitFunc[TInput]
-	buckets   syncMap[bucketSpec[TKey], *bucket]
+	keyer      Keyer[TInput, TKey]
+	limits     []Limit
+	limitFuncs []LimitFunc[TInput]
+	buckets    syncMap[bucketSpec[TKey], *bucket]
 }
 
 // Keyer is a function that takes an input and returns a bucket key.
@@ -25,20 +25,20 @@ type bucketSpec[TKey comparable] struct {
 }
 
 // NewLimiter creates a new rate limiter
-func NewLimiter[TInput any, TKey comparable](keyer Keyer[TInput, TKey], limit Limit) *Limiter[TInput, TKey] {
+func NewLimiter[TInput any, TKey comparable](keyer Keyer[TInput, TKey], limits ...Limit) *Limiter[TInput, TKey] {
 	return &Limiter[TInput, TKey]{
-		keyer: keyer,
-		limit: limit,
+		keyer:  keyer,
+		limits: limits,
 	}
 }
 
 // NewLimiterFunc creates a new rate limiter with a dynamic limit function. Use this if you
 // wish to apply a different limit based on the input, for example by URL path. The LimitFunc
 // takes the same input type as the Keyer function.
-func NewLimiterFunc[TInput any, TKey comparable](keyer Keyer[TInput, TKey], limitFunc LimitFunc[TInput]) *Limiter[TInput, TKey] {
+func NewLimiterFunc[TInput any, TKey comparable](keyer Keyer[TInput, TKey], limitFuncs ...LimitFunc[TInput]) *Limiter[TInput, TKey] {
 	return &Limiter[TInput, TKey]{
-		keyer:     keyer,
-		limitFunc: limitFunc,
+		keyer:      keyer,
+		limitFuncs: limitFuncs,
 	}
 }
 
@@ -49,19 +49,94 @@ func (r *Limiter[TInput, TKey]) Allow(input TInput) bool {
 	return r.allow(input, time.Now())
 }
 
-func (r *Limiter[TInput, TKey]) getBucketSpec(input TInput) bucketSpec[TKey] {
-	return bucketSpec[TKey]{
-		limit:   r.getLimit(input),
-		userKey: r.keyer(input),
+func (r *Limiter[TInput, TKey]) getBucketSpecs(input TInput) []bucketSpec[TKey] {
+	// limits and limitFuncs are mutually exclusive.
+	if len(r.limitFuncs) > 0 {
+		specs := make([]bucketSpec[TKey], len(r.limitFuncs))
+		for i, limitFunc := range r.limitFuncs {
+			specs[i] = bucketSpec[TKey]{
+				limit:   limitFunc(input),
+				userKey: r.keyer(input),
+			}
+		}
+		return specs
+	}
+
+	if len(r.limits) > 0 {
+		specs := make([]bucketSpec[TKey], len(r.limits))
+		for i, limit := range r.limits {
+			specs[i] = bucketSpec[TKey]{
+				limit:   limit,
+				userKey: r.keyer(input),
+			}
+		}
+		return specs
+	}
+
+	return nil
+}
+
+func (r *Limiter[TInput, TKey]) getBucketsAndLimits(input TInput, executionTime time.Time) ([]*bucket, []Limit) {
+	specs := r.getBucketSpecs(input)
+	buckets := make([]*bucket, len(specs))
+	limits := make([]Limit, len(specs))
+
+	// buckets and limits must be the same length and ordering,
+	// so the right limit is applied to the right bucket.
+
+	for i, spec := range specs {
+		b := r.buckets.loadOrStore(spec, newBucket(executionTime, spec.limit))
+		buckets[i] = b
+		limits[i] = spec.limit
+	}
+
+	return buckets, limits
+}
+
+func lockBuckets(buckets []*bucket) (unlock func()) {
+	for _, b := range buckets {
+		b.mu.Lock()
+	}
+	return func() {
+		for _, b := range buckets {
+			b.mu.Unlock()
+		}
 	}
 }
 
 func (r *Limiter[TInput, TKey]) allow(input TInput, executionTime time.Time) bool {
-	key := r.getBucketSpec(input)
-	limit := key.limit
-	b := r.buckets.loadOrStore(key, newBucket(executionTime, limit))
+	// Allow must be true for all limits, a strict AND operation.
+	// If any limit is not allowed, the overall allow is false and
+	// no token is consumed from any bucket.
 
-	return b.Allow(executionTime, limit)
+	buckets, limits := r.getBucketsAndLimits(input, executionTime)
+	unlock := lockBuckets(buckets)
+	defer unlock()
+
+	// specs and buckets must be the same length and ordering,
+	// so the right limit is applied to the right bucket.
+
+	// Check if all buckets allow the token
+	allow := true
+	for i := range buckets {
+		b := buckets[i]
+		limit := limits[i]
+		if !b.hasToken(executionTime, limit) {
+			allow = false
+			break
+		}
+	}
+
+	// Consume tokens only when all buckets allow
+	if allow {
+		for i := range buckets {
+			b := buckets[i]
+			limit := limits[i]
+			b.consumeToken(limit)
+		}
+	}
+
+	return allow
 }
 
 // AllowWithDetails returns true if tokens are available for the given key,
@@ -70,26 +145,48 @@ func (r *Limiter[TInput, TKey]) allow(input TInput, executionTime time.Time) boo
 //
 // If true, it will consume a token from the key's bucket. If false,
 // no token will be consumed.
-func (r *Limiter[TInput, TKey]) AllowWithDetails(input TInput) (bool, Details[TInput, TKey]) {
+func (r *Limiter[TInput, TKey]) AllowWithDetails(input TInput) (bool, []Details[TInput, TKey]) {
 	return r.allowWithDetails(input, time.Now())
 }
 
-func (r *Limiter[TInput, TKey]) allowWithDetails(input TInput, executionTime time.Time) (bool, Details[TInput, TKey]) {
-	spec := r.getBucketSpec(input)
-	limit := spec.limit
+func (r *Limiter[TInput, TKey]) allowWithDetails(input TInput, executionTime time.Time) (bool, []Details[TInput, TKey]) {
+	// Allow must be true for all limits, a strict AND operation.
+	// If any limit is not allowed, the overall allow is false and
+	// no token is consumed from any bucket.
 
-	b := r.buckets.loadOrStore(spec, newBucket(executionTime, limit))
+	buckets, limits := r.getBucketsAndLimits(input, executionTime)
+	unlock := lockBuckets(buckets)
+	defer unlock()
 
-	allowed, bucketTime := b.AllowWithDetails(executionTime, limit)
+	details := make([]Details[TInput, TKey], len(buckets))
 
-	return allowed, Details[TInput, TKey]{
-		allowed:       allowed,
-		executionTime: executionTime,
-		limit:         limit,
-		bucketTime:    bucketTime,
-		bucketInput:   input,
-		bucketKey:     spec.userKey,
+	allowAll := true
+	for i := range buckets {
+		b := buckets[i]
+		limit := limits[i]
+		allow := b.hasToken(executionTime, limit)
+		allowAll = allowAll && allow
+		details[i] = Details[TInput, TKey]{
+			allowed:       allow,
+			executionTime: executionTime,
+			limit:         limit,
+			bucketTime:    b.time,
+			bucketInput:   input,
+			bucketKey:     r.keyer(input),
+		}
 	}
+
+	// Consume tokens only when all buckets allow
+	if allowAll {
+		for i := range buckets {
+			b := buckets[i]
+			limit := limits[i]
+			b.consumeToken(limit)
+			details[i].bucketTime = b.time
+		}
+	}
+
+	return allowAll, details
 }
 
 // Peek returns true if tokens are available for the given key,
@@ -99,11 +196,16 @@ func (r *Limiter[TInput, TKey]) Peek(input TInput) bool {
 }
 
 func (r *Limiter[TInput, TKey]) peek(input TInput, executionTime time.Time) bool {
-	spec := r.getBucketSpec(input)
-	limit := spec.limit
-	b := r.buckets.loadOrReturn(spec, newBucket(executionTime, limit))
+	specs := r.getBucketSpecs(input)
 
-	return b.HasToken(executionTime, limit)
+	for _, spec := range specs {
+		b := r.buckets.loadOrReturn(spec, newBucket(executionTime, spec.limit))
+		if !b.HasToken(executionTime, spec.limit) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // PeekWithDetails returns true if tokens are available for the given key,
@@ -111,25 +213,35 @@ func (r *Limiter[TInput, TKey]) peek(input TInput, executionTime time.Time) bool
 // use these details for logging, returning headers, etc.
 //
 // No tokens are consumed.
-func (r *Limiter[TInput, TKey]) PeekWithDetails(input TInput) (bool, Details[TInput, TKey]) {
+func (r *Limiter[TInput, TKey]) PeekWithDetails(input TInput) (bool, []Details[TInput, TKey]) {
 	return r.peekWithDetails(input, time.Now())
 }
 
-func (r *Limiter[TInput, TKey]) peekWithDetails(input TInput, executionTime time.Time) (bool, Details[TInput, TKey]) {
-	spec := r.getBucketSpec(input)
-	limit := spec.limit
+func (r *Limiter[TInput, TKey]) peekWithDetails(input TInput, executionTime time.Time) (bool, []Details[TInput, TKey]) {
+	specs := r.getBucketSpecs(input)
 
-	b := r.buckets.loadOrReturn(spec, newBucket(executionTime, limit))
-	allowed, bucketTime := b.HasTokenWithDetails(executionTime, limit)
+	details := make([]Details[TInput, TKey], len(specs))
+	allowAll := true
 
-	return allowed, Details[TInput, TKey]{
-		allowed:       allowed,
-		executionTime: executionTime,
-		limit:         limit,
-		bucketTime:    bucketTime,
-		bucketInput:   input,
-		bucketKey:     spec.userKey,
+	for i, spec := range specs {
+		limit := spec.limit
+		// Get the bucket for the given spec, creating it if it doesn't exist.
+		b := r.buckets.loadOrReturn(spec, newBucket(executionTime, limit))
+
+		allow, bucketTime := b.HasTokenWithDetails(executionTime, limit)
+		allowAll = allowAll && allow
+
+		details[i] = Details[TInput, TKey]{
+			allowed:       allow,
+			executionTime: executionTime,
+			limit:         limit,
+			bucketTime:    bucketTime,
+			bucketInput:   input,
+			bucketKey:     spec.userKey,
+		}
 	}
+
+	return allowAll, details
 }
 
 // Wait will poll the [Limiter.Allow] method for a period of time,
@@ -169,20 +281,45 @@ func (r *Limiter[TInput, TKey]) wait(ctx context.Context, input TInput, executio
 // deadline and done functions instead of a context, allowing for deterministic testing.
 func (r *Limiter[TInput, TKey]) waitWithCancellation(
 	input TInput,
-	executionTime time.Time,
+	startTime time.Time,
 	deadline func() (time.Time, bool),
 	done func() <-chan struct{},
 ) bool {
-	spec := r.getBucketSpec(input)
-	limit := spec.limit
-	b := r.buckets.loadOrStore(spec, newBucket(executionTime, limit))
+	// "current" time is meant to be an approximation of the
+	// delta between the start time and the real system clock.
+	currentTime := startTime
 
-	return b.waitWithCancellation(executionTime, limit, deadline, done)
-}
+	for {
+		if r.allow(input, currentTime) {
+			return true
+		}
 
-func (r *Limiter[TInput, TKey]) getLimit(input TInput) Limit {
-	if r.limitFunc != nil {
-		return r.limitFunc(input)
+		// Optimization: find the b	est time to try again
+
+		buckets, limits := r.getBucketsAndLimits(input, currentTime)
+
+		// Pick a default, is there a better way?
+		wait := 100 * time.Millisecond
+		for i := range buckets {
+			b := buckets[i]
+			limit := limits[i]
+			nextToken := b.NextTokenTime(limit)
+			untilNext := nextToken.Sub(currentTime)
+			wait = min(wait, untilNext)
+		}
+
+		// early return if we can't possibly acquire a token before the context is done
+		if deadline, ok := deadline(); ok {
+			if deadline.Before(currentTime.Add(wait)) {
+				return false
+			}
+		}
+
+		select {
+		case <-done():
+			return false
+		case <-time.After(wait):
+			currentTime = currentTime.Add(wait)
+		}
 	}
-	return r.limit
 }

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -101,10 +101,11 @@ func TestLimiter_AllowWithDetails(t *testing.T) {
 
 	allow, details := limiter.allowWithDetails("test-details", now)
 	require.True(t, allow)
-	require.Equal(t, limit, details.Limit())
-	require.Equal(t, now, details.ExecutionTime())
-	require.Equal(t, "test-details", details.BucketKey())
-	require.Equal(t, limit.count-1, details.RemainingTokens())
+	d := details[0]
+	require.Equal(t, limit, d.Limit())
+	require.Equal(t, now, d.ExecutionTime())
+	require.Equal(t, "test-details", d.BucketKey())
+	require.Equal(t, limit.count-1, d.RemainingTokens())
 }
 
 func TestLimiter_Peek_SingleBucket(t *testing.T) {
@@ -258,10 +259,11 @@ func TestLimiter_PeekWithDetails(t *testing.T) {
 
 	allowed, details := limiter.peekWithDetails("test-details", now)
 	require.True(t, allowed)
-	require.Equal(t, limit, details.Limit())
-	require.Equal(t, now, details.ExecutionTime())
-	require.Equal(t, "test-details", details.BucketKey())
-	require.Equal(t, limit.count, details.RemainingTokens())
+	d := details[0]
+	require.Equal(t, limit, d.Limit())
+	require.Equal(t, now, d.ExecutionTime())
+	require.Equal(t, "test-details", d.BucketKey())
+	require.Equal(t, limit.count, d.RemainingTokens())
 }
 
 func TestLimiter_Allow_SingleBucket_Func(t *testing.T) {
@@ -362,10 +364,11 @@ func TestLimiter_AllowWithDetails_Func(t *testing.T) {
 
 	allow, details := limiter.allowWithDetails("test-details", now)
 	require.True(t, allow)
-	require.Equal(t, limit, details.Limit())
-	require.Equal(t, now, details.ExecutionTime())
-	require.Equal(t, "test-details", details.BucketKey())
-	require.Equal(t, limit.count-1, details.RemainingTokens())
+	d := details[0]
+	require.Equal(t, limit, d.Limit())
+	require.Equal(t, now, d.ExecutionTime())
+	require.Equal(t, "test-details", d.BucketKey())
+	require.Equal(t, limit.count-1, d.RemainingTokens())
 }
 
 func TestLimiter_Peek_SingleBucket_Func(t *testing.T) {
@@ -523,10 +526,11 @@ func TestLimiter_PeekWithDetails_Func(t *testing.T) {
 
 	allowed, details := limiter.peekWithDetails("test-details", now)
 	require.True(t, allowed)
-	require.Equal(t, limit, details.Limit())
-	require.Equal(t, now, details.ExecutionTime())
-	require.Equal(t, "test-details", details.BucketKey())
-	require.Equal(t, limit.count, details.RemainingTokens())
+	d := details[0]
+	require.Equal(t, limit, d.Limit())
+	require.Equal(t, now, d.ExecutionTime())
+	require.Equal(t, "test-details", d.BucketKey())
+	require.Equal(t, limit.count, d.RemainingTokens())
 }
 
 func TestLimiter_UsesLimitFunc(t *testing.T) {
@@ -543,7 +547,8 @@ func TestLimiter_UsesLimitFunc(t *testing.T) {
 		for i := range 3 {
 			allow, details := limiter.allowWithDetails(i+1, time.Now())
 			require.True(t, allow)
-			require.Equal(t, limitFunc(i+1), details.Limit())
+			d := details[0]
+			require.Equal(t, limitFunc(i+1), d.Limit())
 		}
 	}
 	{
@@ -553,7 +558,8 @@ func TestLimiter_UsesLimitFunc(t *testing.T) {
 		for i := range 3 {
 			allow, details := limiter.allowWithDetails(i+1, time.Now())
 			require.True(t, allow)
-			require.Equal(t, limit, details.Limit())
+			d := details[0]
+			require.Equal(t, limit, d.Limit())
 		}
 	}
 }


### PR DESCRIPTION
Allow multiple limits per limiter. allow becomes defined as “all limits must be  allowed”, but if any are denied, then no tokens will be consumed from any bucket.

In progress, more to do.

- New tests for multiple limits
- New tests for multiple details
- Is `wait` right and optimal?