### PR TITLE
Implement best-effort FIFO ordering on Limiter.Wait

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,21 @@
 # Go Rate Limiter Library - Coding Instructions
 
+## Design goals
+
+### Composability
+- This library is intended to allow users to create complex rate limiting policies by composing elements
+- Users should be able to mix and match different limiters, keyers, and strategies to create the desired behavior.
+- The library should behave predictably given the user's configuration. It should be easy to reason about by users.
+- We wish to be like Go's standard library: simple, composable, and predictable.
+- The library will abstract away the difficult or tedious parts of rate limiting, such as concurrency and timing issues, so users can focus on their application logic. Make easy things easy, and hard things possible.
+
 ## Testing Conventions
 
 ### Race Detection
 - Always run Go tests with the `-race` flag to catch race conditions and ensure clean concurrency
 - Essential for this codebase since it heavily uses concurrent operations
+- Use 10 second timeout for tests to prevent hanging
+- The agent should run tests directly if possible, instead of asking me to do it
 
 ### Test Structure Patterns
 - Every test function must start with `t.Parallel()` to enable concurrent test execution

--- a/limiter.go
+++ b/limiter.go
@@ -500,8 +500,8 @@ func (r *Limiter[TInput, TKey]) waitNWithCancellation(
 		var wait time.Duration
 		for i, b := range buckets {
 			limit := limits[i]
-			nextTokenTime := b.nextTokensTime(limit, n)
-			untilNext := nextTokenTime.Sub(currentTime)
+			nextTokensTime := b.nextTokensTime(limit, n)
+			untilNext := nextTokensTime.Sub(currentTime)
 			if i == 0 || untilNext > wait {
 				wait = untilNext
 			}

--- a/syncmap.go
+++ b/syncmap.go
@@ -36,3 +36,8 @@ func (sm *syncMap[K, V]) count() int {
 	})
 	return count
 }
+
+// delete removes a key from the map
+func (sm *syncMap[K, V]) delete(key K) {
+	sm.m.Delete(key)
+}


### PR DESCRIPTION
Addresses https://github.com/clipperhouse/rate/issues/14

Use the behavior of mutex & the Go runtime to improve ordering guarantees. Mutex scheduling is de facto queue-like. Copilot + Gemini did most of it.

I asked Copilot to explain (Gemini IIRC, but may have been Claude):

<details>
<summary>So multiple goroutines hitting the same mutex will queue in order? Are you sure ?</summary>

> You are absolutely right to question that, and I need to be more precise. My previous explanation was an oversimplification.
>
> The official Go language specification does not strictly guarantee FIFO ordering for goroutines waiting on a sync.Mutex. However, the practical implementation of the mutex in modern Go (since version 1.8) makes it behave in a way that is effectively FIFO for this use case, preventing a situation called "starvation."
>
> Let me clarify the behavior:
>
> sync.Mutex Fairness and Starvation Mode
> The Go sync.Mutex has two modes of operation:
>
> Normal Mode: When a goroutine unlocks a mutex, if there are other goroutines waiting, it wakes one of them up. At the same time, a newly arriving goroutine that wasn't waiting might also try to acquire the lock. In this state, the new goroutine can "barge" ahead and acquire the lock before the awakened goroutine gets a chance to run. This is not FIFO.
>
> Starvation Mode: This is the crucial part. If a goroutine has to wait for its turn for more than 1 millisecond, the mutex switches into "starvation mode." In this mode:
>
> The lock is passed directly from the unlocking goroutine to the goroutine that has been waiting the longest (the one at the front of the queue).
> Newly arriving goroutines are not allowed to acquire the lock, even if it's unlocked. They are placed at the tail of the waiting queue.
> The mutex remains in starvation mode until all waiting goroutines have had their turn.
> How This Applies to the Rate Limiter
> In our Wait function, a goroutine that needs to wait will almost certainly wait for more than 1 millisecond. The calculated wait duration is based on when the next token becomes available, which is typically in the order of milliseconds or more.
>
> Because of this, any sync.Mutex associated with a busy key will quickly enter starvation mode. Once in that mode, it guarantees that the longest-waiting goroutine gets the lock next.
>
> So, while you are correct that the language spec doesn't promise FIFO, the runtime's implementation of sync.Mutex provides the fairness we need to ensure that waiting requests are processed in the order they arrived, without letting new requests cut in line.
>
> Thank you for pushing for a more precise explanation. It's a critical distinction.
</details>

Testing seems to hold up. The question is to what degree we can offer a guarantee. In the real world, how many 9’s? Highly contended scenarios, with multiple callers within 1ms, would likely have lower guarantees. I describe it as best-effort in the comments.

The design goal is to reduce surprises. Probably-ordered is better than unordered in that regard.

This PR also implements cleanup of the queue of waiters (mutexes) via reference counting.