### PR TITLE
Use a sync.Mutex on bucket instead of RWMutex

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -4,4 +4,6 @@ go 1.24
 
 require github.com/clipperhouse/rate v0.3.0
 
+replace github.com/clipperhouse/rate => ../
+
 require github.com/clipperhouse/ntime v0.1.1 // indirect

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -4,6 +4,4 @@ go 1.24
 
 require github.com/clipperhouse/rate v0.3.0
 
-replace github.com/clipperhouse/rate => ../
-
 require github.com/clipperhouse/ntime v0.1.1 // indirect

--- a/benchmarks/limiter_peek_bench_test.go
+++ b/benchmarks/limiter_peek_bench_test.go
@@ -14,26 +14,57 @@ func BenchmarkLimiter_Peek(b *testing.B) {
 		}
 
 		b.Run("SingleLimit", func(b *testing.B) {
-			limit := rate.NewLimit(1000000, time.Second)
-			limiter := rate.NewLimiter(keyFunc, limit)
+			b.Run("Serial", func(b *testing.B) {
+				limit := rate.NewLimit(1000000, time.Second)
+				limiter := rate.NewLimiter(keyFunc, limit)
 
-			b.ReportAllocs()
+				b.ReportAllocs()
 
-			for b.Loop() {
-				limiter.PeekN(0, 1)
-			}
+				for b.Loop() {
+					limiter.PeekN(0, 1)
+				}
+			})
+
+			b.Run("Parallel", func(b *testing.B) {
+				limit := rate.NewLimit(1000000, time.Second)
+				limiter := rate.NewLimiter(keyFunc, limit)
+
+				b.ReportAllocs()
+
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						limiter.PeekN(0, 1)
+					}
+				})
+			})
 		})
 
 		b.Run("MultipleLimits", func(b *testing.B) {
-			limit1 := rate.NewLimit(1000000, time.Second)
-			limit2 := rate.NewLimit(500000, time.Second/2)
-			limiter := rate.NewLimiter(keyFunc, limit1, limit2)
+			b.Run("Serial", func(b *testing.B) {
+				limit1 := rate.NewLimit(1000000, time.Second)
+				limit2 := rate.NewLimit(500000, time.Second/2)
+				limiter := rate.NewLimiter(keyFunc, limit1, limit2)
 
-			b.ReportAllocs()
+				b.ReportAllocs()
 
-			for b.Loop() {
-				limiter.PeekN(0, 1)
-			}
+				for b.Loop() {
+					limiter.PeekN(0, 1)
+				}
+			})
+
+			b.Run("Parallel", func(b *testing.B) {
+				limit1 := rate.NewLimit(1000000, time.Second)
+				limit2 := rate.NewLimit(500000, time.Second/2)
+				limiter := rate.NewLimiter(keyFunc, limit1, limit2)
+
+				b.ReportAllocs()
+
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						limiter.PeekN(0, 1)
+					}
+				})
+			})
 		})
 	})
 
@@ -44,28 +75,65 @@ func BenchmarkLimiter_Peek(b *testing.B) {
 		}
 
 		b.Run("SingleLimit", func(b *testing.B) {
-			limit := rate.NewLimit(1000000, time.Second)
-			limiter := rate.NewLimiter(keyFunc, limit)
+			b.Run("Serial", func(b *testing.B) {
+				limit := rate.NewLimit(1000000, time.Second)
+				limiter := rate.NewLimiter(keyFunc, limit)
 
-			b.ResetTimer()
-			b.ReportAllocs()
+				b.ResetTimer()
+				b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
-				limiter.PeekN(i%buckets, 1)
-			}
+				for i := 0; i < b.N; i++ {
+					limiter.PeekN(i%buckets, 1)
+				}
+			})
+
+			b.Run("Parallel", func(b *testing.B) {
+				limit := rate.NewLimit(1000000, time.Second)
+				limiter := rate.NewLimiter(keyFunc, limit)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						limiter.PeekN(i%buckets, 1)
+						i++
+					}
+				})
+			})
 		})
 
 		b.Run("MultipleLimits", func(b *testing.B) {
-			limit1 := rate.NewLimit(1000000, time.Second)
-			limit2 := rate.NewLimit(500000, time.Second/2)
-			limiter := rate.NewLimiter(keyFunc, limit1, limit2)
+			b.Run("Serial", func(b *testing.B) {
+				limit1 := rate.NewLimit(1000000, time.Second)
+				limit2 := rate.NewLimit(500000, time.Second/2)
+				limiter := rate.NewLimiter(keyFunc, limit1, limit2)
 
-			b.ResetTimer()
-			b.ReportAllocs()
+				b.ResetTimer()
+				b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
-				limiter.PeekN(i%buckets, 1)
-			}
+				for i := 0; i < b.N; i++ {
+					limiter.PeekN(i%buckets, 1)
+				}
+			})
+
+			b.Run("Parallel", func(b *testing.B) {
+				limit1 := rate.NewLimit(1000000, time.Second)
+				limit2 := rate.NewLimit(500000, time.Second/2)
+				limiter := rate.NewLimiter(keyFunc, limit1, limit2)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						limiter.PeekN(i%buckets, 1)
+						i++
+					}
+				})
+			})
 		})
 	})
 }

--- a/bucket.go
+++ b/bucket.go
@@ -20,7 +20,7 @@ import (
 // the right thing.
 type bucket struct {
 	time ntime.Time
-	mu   sync.RWMutex
+	mu   sync.Mutex
 }
 
 func newBucket(executionTime ntime.Time, limit Limit) bucket {

--- a/limiter_peek.go
+++ b/limiter_peek.go
@@ -39,9 +39,9 @@ func (r *Limiter[TInput, TKey]) peekN(input TInput, executionTime ntime.Time, n 
 	// without needing to collect and lock them all together
 	for _, limit := range limits {
 		if b, ok := r.buckets.load(userKey, limit); ok {
-			b.mu.RLock()
+			b.mu.Lock()
 			allowed := b.hasTokens(executionTime, limit, n)
-			b.mu.RUnlock()
+			b.mu.Unlock()
 			if !allowed {
 				return false
 			}
@@ -99,7 +99,7 @@ func (r *Limiter[TInput, TKey]) peekNWithDetails(input TInput, executionTime nti
 	// without needing to collect and lock them all together
 	for _, limit := range limits {
 		if b, ok := r.buckets.load(userKey, limit); ok {
-			b.mu.RLock()
+			b.mu.Lock()
 
 			allowAll = allowAll && b.hasTokens(executionTime, limit, n)
 			rt := b.remainingTokens(executionTime, limit)
@@ -111,7 +111,7 @@ func (r *Limiter[TInput, TKey]) peekNWithDetails(input TInput, executionTime nti
 				retryAfter = ra
 			}
 
-			b.mu.RUnlock()
+			b.mu.Unlock()
 
 			continue
 		}
@@ -195,7 +195,7 @@ func (r *Limiter[TInput, TKey]) peekNWithDebug(input TInput, executionTime ntime
 	// without needing to collect and lock them all together
 	for _, limit := range limits {
 		if b, ok := r.buckets.load(userKey, limit); ok {
-			b.mu.RLock()
+			b.mu.Lock()
 
 			allow := b.hasTokens(executionTime, limit, n)
 			debugs = append(debugs, Debug[TInput, TKey]{
@@ -210,7 +210,7 @@ func (r *Limiter[TInput, TKey]) peekNWithDebug(input TInput, executionTime ntime
 				retryAfter:      b.retryAfter(executionTime, limit, n),
 			})
 
-			b.mu.RUnlock()
+			b.mu.Unlock()
 			allowAll = allowAll && allow
 
 			continue


### PR DESCRIPTION
Not sure that `RWMutex` is buying anything. The original intuition was that `Peek` methods are read-only and would benefit from the concurrent reads of `RWMutex`.

But the `RWMutex` type is larger and more complex than `Mutex`.

`RWMutex` prevents others from taking a write lock. `Allow` requires that. So, `Peek` would effectively block `Allow` regardless of mutex type.

The other situation is concurrent peeks on the same bucket. Maybe that’s worse with a regular mutex, but I suspect it’s a wash.

